### PR TITLE
Remove buggy done optimization

### DIFF
--- a/src/main/java/org/boon/primitive/ReaderCharacterSource.java
+++ b/src/main/java/org/boon/primitive/ReaderCharacterSource.java
@@ -82,10 +82,7 @@ public class ReaderCharacterSource implements CharacterSource {
              more = false;
              done = true;
         } else {
-            if (length<readBuf.length-5) {
-                     done = true;
-                     more = true;
-            }
+             more = true;
         }
     }
 


### PR DESCRIPTION
`ReaderCharacterSource` has this optimization tentative for determining when it's done.

This might be working with some Reader implementations, such as `CharArrayReader`, but clearly doesn't with some others. For example, InputStreamReader use an internal 8k buffer, so as Boon buffer is 10k, so this condition is always matched, causing done to be set way to early.

The only reliable way to determine done is to stick to Reader specification and watch for a -1 length.
