### PR TITLE
quote empty string

### DIFF
--- a/src/main/java/org/boon/primitive/CharBuf.java
+++ b/src/main/java/org/boon/primitive/CharBuf.java
@@ -457,8 +457,7 @@ public class CharBuf extends Writer implements CharSequence {
 
 
     public final CharBuf addJsonEscapedString( final char[] charArray ) {
-        if (charArray.length == 0 ) return this;
-        if ( hasAnyJSONControlOrUnicodeChars( charArray )) {
+        if ( charArray.length > 0 && hasAnyJSONControlOrUnicodeChars( charArray )) {
             return doAddJsonEscapedString(charArray);
         } else {
             return this.addQuoted ( charArray );


### PR DESCRIPTION
there be some pseudo codes.
str = {"empty":"","docId":111,"serviceName":"cafe"}
map = parser.parse(str);
print serializer.serialize(map)
{"empty":,"docId":111,"serviceName":"cafe"}

even if set includeEmpty().includeNulls().includeDefaultValues() methods.
this bug(?) is shown on 0.10 and 0.11-SNAPSHOT(from github).
