### PR TITLE
Added support for Jackson false ISO8601 datetime format

### DIFF
--- a/src/main/java/org/boon/core/value/CharSequenceValue.java
+++ b/src/main/java/org/boon/core/value/CharSequenceValue.java
@@ -239,6 +239,8 @@ public class CharSequenceValue implements Value, CharSequence {
                 if ( Dates.isJsonDate ( buffer, startIndex, endIndex ) ) {
                     return Dates.fromJsonDate ( buffer, startIndex, endIndex );
 
+                } else if ( Dates.isISO8601Jackson(buffer, startIndex, endIndex) ) {
+                    return Dates.fromISO8601Jackson(buffer, startIndex, endIndex);
                 } else if ( Dates.isISO8601 ( buffer, startIndex, endIndex ) ) {
                     return Dates.fromISO8601 ( buffer, startIndex, endIndex );
                 } else {

--- a/src/test/java/org/boon/core/DatesTest.java
+++ b/src/test/java/org/boon/core/DatesTest.java
@@ -63,6 +63,15 @@ public class DatesTest {
     }
 
 
+    @Test
+    public void testIsoJacksonLongDate() {
+        String test = "2014-05-29T08:54:09.764+0200";
+        Date date = Dates.fromISO8601Jackson(test);
+        Date date2 = Dates.fromISO8601Jackson_(test);
+
+        assertEquals( date2.toString(), "" + date );
+    }
+
     /*
         var d=new Date();
         var s = JSON.stringify(d);


### PR DESCRIPTION
I want to switch from Jackson to boon, so I need this to respect backward compatibility

http://svn.codehaus.org/jackson/tags/1.9/1.9.4/src/mapper/java/org/codehaus/jackson/map/util/StdDateFormat.java
http://www.boyunjian.com/javasrc/com.fasterxml.jackson.core/jackson-databind/2.1.1/_/com/fasterxml/jackson/databind/util/StdDateFormat.java
