### PR TITLE
Builder mode setter support

### DIFF
--- a/src/main/java/org/boon/core/reflection/Reflection.java
+++ b/src/main/java/org/boon/core/reflection/Reflection.java
@@ -636,7 +636,6 @@ public class Reflection {
         try {
 
             if ( method.getParameterTypes().length == 1
-                    && method.getReturnType() == void.class
                     && name.startsWith( "set" ) ) {
                 Pair<Method> pair = new Pair<Method>();
                 pair.setFirst( method );

--- a/src/test/java/org/boon/json/JsonArrayPropertyTest.java
+++ b/src/test/java/org/boon/json/JsonArrayPropertyTest.java
@@ -14,7 +14,6 @@ public class JsonArrayPropertyTest {
     @Before
     public void setUp() throws Exception {
         objectMapper = new ObjectMapperImpl(new JsonParserFactory().usePropertyOnly(), new JsonSerializerFactory().usePropertyOnly());
-
     }
 
     @Test
@@ -42,8 +41,9 @@ public class JsonArrayPropertyTest {
             return typeName1;
         }
 
-        public void setTypeName(String typeName) {
+        public ApiDynamicType setTypeName(String typeName) {
             this.typeName1 = typeName;
+            return this;
         }
 
         public ApiDynamicTypeField[] getFields() {


### PR DESCRIPTION
I removed the void return type check for setter resolution, because you can not have two methods with the same signature (one void and one that returns something).
Nothing changed overall, only that now I van use builder style setters to simplify my code.

``` java
public class CollectionHolder {
    private String[] array;
    private Collection<String> collection;

    public CollectionHolder setArray(String[] array) {
        this.array = array;
        return this;
    }
}
```
