### PR TITLE
Handle early access JDK versions

### DIFF
--- a/src/main/java/org/boon/core/Sys.java
+++ b/src/main/java/org/boon/core/Sys.java
@@ -82,7 +82,10 @@ public class Sys {
                     v = new BigDecimal ("1.9" );
                 }
 
-                b = Integer.parseInt ( split[ 1 ] );
+                String build = split[ 1 ];
+                if (build.endsWith("-ea"))
+                  build.substring(0, build.length() - 3);
+                b = Integer.parseInt ( build );
             } catch ( Exception ex ) {
                 ex.printStackTrace ();
                 System.err.println ( "Unable to determine build number or version" );


### PR DESCRIPTION
Yeah, I do run with early access JDK versions.
I'm a pita, I know, but we might be legion out there.

```
java.lang.NumberFormatException: For input string: "60-ea"
    at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
    at java.lang.Integer.parseInt(Integer.java:492)
    at java.lang.Integer.parseInt(Integer.java:527)
    at org.boon.core.Sys.<clinit>(Sys.java:85)
    at org.boon.collections.LazyMap.buildIfNeeded(LazyMap.java:130)
    at org.boon.collections.LazyMap.containsKey(LazyMap.java:116)
```
