### PR TITLE
Fix '*-ea' version string handling

### DIFF
--- a/src/main/java/org/boon/core/Sys.java
+++ b/src/main/java/org/boon/core/Sys.java
@@ -84,13 +84,13 @@ public class Sys {
 
                 String build = split[ 1 ];
                 if (build.endsWith("-ea"))
-                  build.substring(0, build.length() - 3);
+                  build = build.substring(0, build.length() - 3);
                 b = Integer.parseInt ( build );
             } catch ( Exception ex ) {
                 ex.printStackTrace ();
                 System.err.println ( "Unable to determine build number or version" );
             }
-        } else if ("1.8.0".equals(sversion)) {
+        } else if ("1.8.0".equals(sversion) || "1.8.0-ea".equals(sversion)) {
             b = -1;
             v = new BigDecimal("1.8");
         } else {


### PR DESCRIPTION
I ran into an issue using an old "early access" version of Java 8 with version number "1.8.0-ea", which causes a NumberFormatException in [Sys.java#L97](https://github.com/RichardHightower/boon/blob/0ad64c28de9c514c74090b22e61f53dc0869e9dd/src/main/java/org/boon/core/Sys.java#L97). Seeing that "1.8.0" is handled as special case, I simply did the same for "1.8.0-ea".

I also noticed there's a substring expression where the return value is not used.
