### PR TITLE
SortTest fails on Norwegian locale

### DIFF
--- a/src/test/java/org/boon/tests/SortTest.java
+++ b/src/test/java/org/boon/tests/SortTest.java
@@ -50,8 +50,8 @@ public class SortTest {
     public void setUp() throws Exception {
         list = Lists.list(
                 Employee.employee( "zzz", "LastA", "120", "5.29.1970:00:00:01", 100 ),
-                Employee.employee( "zaaa", "bbb", "124", "5.29.1960:00:00:00", 200 ),
-                Employee.employee( "zaaa", "aaa", "123", "5.29.1970:00:00:01", 100 ),
+                Employee.employee( "zbbb", "bbb", "124", "5.29.1960:00:00:00", 200 ),
+                Employee.employee( "zbbb", "aaa", "123", "5.29.1970:00:00:01", 100 ),
                 Employee.employee( "bababa", "LastB", "125", "5.29.1960:00:00:00", 200 ),
                 Employee.employee( "BAbaba", "LastB", "126", "5.29.1960:00:00:00", 200 )
 
@@ -67,8 +67,8 @@ public class SortTest {
         List<String> firstNames = BeanUtils.idxList( Typ.string, list, "firstName" );
         assertEquals( "bababa", firstNames.get( 0 ) );
         assertEquals( "BAbaba", firstNames.get( 1 ) );
-        assertEquals( "zaaa", firstNames.get( 2 ) );
-        assertEquals( "zaaa", firstNames.get( 3 ) );
+        assertEquals( "zbbb", firstNames.get( 2 ) );
+        assertEquals( "zbbb", firstNames.get( 3 ) );
         assertEquals( "zzz", firstNames.get( 4 ) );
 
     }
@@ -83,8 +83,8 @@ public class SortTest {
 
         assertEquals( "bababa", firstNames.get( 0 ) );
         assertEquals( "BAbaba", firstNames.get( 1 ) );
-        assertEquals( "zaaa", firstNames.get( 2 ) );
-        assertEquals( "zaaa", firstNames.get( 3 ) );
+        assertEquals( "zbbb", firstNames.get( 2 ) );
+        assertEquals( "zbbb", firstNames.get( 3 ) );
         assertEquals( "zzz", firstNames.get( 4 ) );
 
     }


### PR DESCRIPTION
This is because "aa" is interpreted as "å", which should come after "z".

Fixes #229
