### PR TITLE
Fix #313 - Add set(idx, obj) method for ValueList

### DIFF
--- a/boon/src/main/java/org/boon/core/value/ValueList.java
+++ b/boon/src/main/java/org/boon/core/value/ValueList.java
@@ -99,6 +99,9 @@ public class ValueList extends AbstractList<Object> implements List<Object> {
         return list.add( obj );
     }
 
+    public Object set(int index, Object element) {
+        return list.set(index, element);
+    }
 
     public void chopList() {
 


### PR DESCRIPTION
Calling set(idx, obj) on ValueList throws an
UnsupportedOperationException. Implement the method to update the
backing List instead.